### PR TITLE
Demo Compatibility with Godot 4.2

### DIFF
--- a/game/main.tscn
+++ b/game/main.tscn
@@ -2,8 +2,8 @@
 
 [ext_resource type="Script" path="res://music_vis.gd" id="1_7bol8"]
 [ext_resource type="Shader" path="res://note_vis_shader.gdshader" id="2_uwn88"]
-[ext_resource type="MidiResource" uid="uid://b7orc63h2n67b" path="res://mii_channel.mid" id="3_hmfnq"]
-[ext_resource type="AudioStream" uid="uid://c2p2hlfeyvhsk" path="res://mii_channel.ogg" id="4_pljbq"]
+[ext_resource type="AudioStream" uid="uid://bib56neltjbos" path="res://zeal.ogg" id="3_8807r"]
+[ext_resource type="MidiResource" uid="uid://bwk6t11415q6n" path="res://zeal.mid" id="3_l8227"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_2soq2"]
 render_priority = 0
@@ -63,7 +63,7 @@ script = ExtResource("1_7bol8")
 note_materials = Array[Material]([SubResource("ShaderMaterial_2soq2"), SubResource("ShaderMaterial_33vtw"), SubResource("ShaderMaterial_jh5ke"), SubResource("ShaderMaterial_4arlw"), SubResource("ShaderMaterial_wg5fx"), SubResource("ShaderMaterial_gw6ig"), SubResource("ShaderMaterial_utwia"), SubResource("ShaderMaterial_grq4g")])
 
 [node name="MidiPlayer" type="MidiPlayer" parent="."]
-midi = ExtResource("3_hmfnq")
+midi = ExtResource("3_l8227")
 process_thread_group = 0
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
@@ -80,6 +80,6 @@ size = Vector3(18, 0.1, 1)
 environment = SubResource("Environment_6map0")
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
-stream = ExtResource("4_pljbq")
+stream = ExtResource("3_8807r")
 volume_db = -10.0
 autoplay = true

--- a/game/main.tscn
+++ b/game/main.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=16 format=3 uid="uid://cf5sqk6dd4esg"]
 
 [ext_resource type="Script" path="res://music_vis.gd" id="1_7bol8"]
-[ext_resource type="MidiResource" uid="uid://bwk6t11415q6n" path="res://zeal.mid" id="2_71f2d"]
 [ext_resource type="Shader" path="res://note_vis_shader.gdshader" id="2_uwn88"]
-[ext_resource type="AudioStream" uid="uid://bib56neltjbos" path="res://zeal.ogg" id="3_8807r"]
+[ext_resource type="MidiResource" uid="uid://b7orc63h2n67b" path="res://mii_channel.mid" id="3_hmfnq"]
+[ext_resource type="AudioStream" uid="uid://c2p2hlfeyvhsk" path="res://mii_channel.ogg" id="4_pljbq"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_2soq2"]
 render_priority = 0
@@ -63,7 +63,8 @@ script = ExtResource("1_7bol8")
 note_materials = Array[Material]([SubResource("ShaderMaterial_2soq2"), SubResource("ShaderMaterial_33vtw"), SubResource("ShaderMaterial_jh5ke"), SubResource("ShaderMaterial_4arlw"), SubResource("ShaderMaterial_wg5fx"), SubResource("ShaderMaterial_gw6ig"), SubResource("ShaderMaterial_utwia"), SubResource("ShaderMaterial_grq4g")])
 
 [node name="MidiPlayer" type="MidiPlayer" parent="."]
-midi = ExtResource("2_71f2d")
+midi = ExtResource("3_hmfnq")
+process_thread_group = 0
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 transform = Transform3D(-0.392767, 0.353553, -0.848961, 0.480471, 0.866026, 0.138372, 0.784144, -0.353553, -0.510018, -2, 2, 2)
@@ -79,6 +80,6 @@ size = Vector3(18, 0.1, 1)
 environment = SubResource("Environment_6map0")
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
-stream = ExtResource("3_8807r")
+stream = ExtResource("4_pljbq")
 volume_db = -10.0
 autoplay = true

--- a/game/music_vis.gd
+++ b/game/music_vis.gd
@@ -5,7 +5,7 @@ extends Node
 var notes = []
 var notes_on = {}
 
-var midi_player: MidiPlayer
+var midi_player: MidiPlayer;
 
 # Called when the node enters the scene tree for the first time.
 func _ready():

--- a/game/music_vis.gd
+++ b/game/music_vis.gd
@@ -5,7 +5,7 @@ extends Node
 var notes = []
 var notes_on = {}
 
-var midi_player: MidiPlayer;
+var midi_player: MidiPlayer
 
 # Called when the node enters the scene tree for the first time.
 func _ready():

--- a/game/project.godot
+++ b/game/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="GDExtensionGodotMidi"
 run/main_scene="res://main.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 config/icon="res://icon.png"
 
 [editor_plugins]


### PR DESCRIPTION
Hi! I had an idea for a rhythm game utilizing midi and just started development, so this library is an incredible gem! I'm running Godot 4.2 and when I ran the demo game, it crashed on trying to run the project. I changed a couple things so it doesn't crash for 4.2, I haven't tested these changes on any other version. I'm not quite sure why it was crashing, perhaps it was Godot versioning when the project was updated?

Either way, thanks for the incredible library, can't wait to start using it! 