### PR TITLE
Resolve a few build errors on MacOS

### DIFF
--- a/extension/src/midi_parser.cpp
+++ b/extension/src/midi_parser.cpp
@@ -253,6 +253,11 @@ void MidiParser::MidiTrackChunk::IngestMetaEvent(MidiEventMeta &meta_event, Midi
         // set end of track flag
         header.end_of_track = true;
     }
+    default:
+    {
+        // unknown meta event
+        break;
+    }
     }
 }
 

--- a/extension/src/midi_parser.h
+++ b/extension/src/midi_parser.h
@@ -99,6 +99,7 @@ public:
         int32_t channel;
         int32_t delta_time;
 
+        virtual ~MidiEvent() = default;
         MidiEvent(int32_t channel, int32_t delta_time);
         MidiEvent(const MidiEvent &other);
 

--- a/extension/src/midi_player.cpp
+++ b/extension/src/midi_player.cpp
@@ -58,7 +58,7 @@ void MidiPlayer::process_delta(double delta)
         {
             // process each track
             bool has_more_events = false;
-            for (size_t i = 0; i < this->midi->get_track_count(); i++)
+            for (uint64_t i = 0; i < this->midi->get_track_count(); i++)
             {
                 // get events for this track
                 Array events = this->midi->get_tracks()[i].get("events");
@@ -74,7 +74,7 @@ void MidiPlayer::process_delta(double delta)
                 }
 
                 // search forward in time
-                for (size_t j = index_off; j < events.size(); j++)
+                for (uint64_t j = index_off; j < events.size(); j++)
                 {
                     Dictionary event = events[j];
                     double event_time = event.get("time", 0);


### PR DESCRIPTION
Tested on a Intel Core i7 mac running MacOS 12.6, YMMV.
SCons: v4.6.0.e5eef322a4a727b96358a436dca46e8085ac8692

One other solution would be to static cast before converting to Variant versus changing the type of the loop variable. Something like `this->track_index_offsets[i] = static_cast<int64_t>(j);` ... 



